### PR TITLE
Add missing semicolon

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ home-manager = {
   users = {
     "username" = import ./home.nix;
   };
-}
+};
 ```
 
 ## example module / main-user.nix


### PR DESCRIPTION
This PR adds the missing semicolon in home-manager option configuration so that the code can be copied directly into `configuration.nix` and, after modifying the username, builds.