### PR TITLE
Update README.md to use #nixos configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ $ sudo nix flake init --template github:vimjoyer/flake-starter-config
 ## rebuilding with flakes enabled
 
 ```bash
-$ sudo nixos-rebuild switch --flake /etc/nixos/#default
+$ sudo nixos-rebuild switch --flake /etc/nixos/#nixos
 ```
 
 ## generating home.nix


### PR DESCRIPTION
Without this, following the README.md will fail at this step: $ sudo nixos-rebuild switch --flake /etc/nixos/#default becauase it references a non-existent configuration name. This name was changed in 812aff2.